### PR TITLE
Fix wrong repository action on Filial delete

### DIFF
--- a/src/main/java/com/estoque/service/FilialService.java
+++ b/src/main/java/com/estoque/service/FilialService.java
@@ -61,7 +61,7 @@ public class FilialService {
     @Transactional
     public void excluir(Long id) {
         Filial filial = getFilial(id);
-        filialRepository.save(filial);
+        filialRepository.delete(filial);
     }
 
     private Filial getFilial(Long id) {

--- a/src/test/java/com/estoque/service/FilialServiceTest.java
+++ b/src/test/java/com/estoque/service/FilialServiceTest.java
@@ -263,8 +263,7 @@ public class FilialServiceTest {
 
         // Assert
         verify(filialRepository).findById(1L);
-
-        verify(filialRepository).save(filial);
-        verify(filialRepository, never()).delete(any(Filial.class));
+        verify(filialRepository).delete(filial);
+        verify(filialRepository, never()).save(any(Filial.class));
     }
 }


### PR DESCRIPTION
## Summary
- delete filial when deleting from service layer
- update unit test to check for delete action

## Testing
- `mvnw -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687561863d60832499ccbfd1a50a69a2